### PR TITLE
Added --openssl-legacy-provider to start react script to avoid error

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "dependencies": {
     "lodash": "4.17.15",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",    
-    "react-trello": "2.2.10",    
-    "redux-actions": "2.6.5", 
+    "react-dom": "^17.0.1",
+    "react-trello": "2.2.10",
+    "redux-actions": "2.6.5",
     "redux-logger": "3.0.6",
     "styled-components": "5.0.1"
   },
@@ -15,7 +15,7 @@
     "react-scripts": "3.4.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Avoid "error:0308010C:digital envelope routines::unsupported" when attempting to `yarn start` by allowing legacy SSL connection to the local dev server. Should be safe on a local dev machine.

See also: https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported